### PR TITLE
Diskette size change

### DIFF
--- a/code/modules/virus2/items_devices.dm
+++ b/code/modules/virus2/items_devices.dm
@@ -71,6 +71,7 @@
 	name = "Blank GNA disk"
 	icon = 'icons/obj/cloning.dmi'
 	icon_state = "datadisk0"
+	w_class = 1
 	var/datum/disease2/effectholder/effect = null
 	var/stage = 1
 


### PR DESCRIPTION
What kind of 5" diskette NT was using. No more w_class 3 disks, now you .can actually put these in a box.
