### PR TITLE
Mob fire adjustments

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1782,19 +1782,12 @@
 /mob/living/carbon/human/handle_fire()
 	if(..())
 		return
-	var/thermal_protection = 0 //Simple check to estimate how protected we are against multiple temperatures
-	if(wear_suit)
-		if(wear_suit.max_heat_protection_temperature >= FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE)
-			thermal_protection += (wear_suit.max_heat_protection_temperature*0.7)
-	if(head)
-		if(head.max_heat_protection_temperature >= FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE)
-			thermal_protection += (head.max_heat_protection_temperature*THERMAL_PROTECTION_HEAD)
-	thermal_protection = round(thermal_protection)
-	if(thermal_protection >= FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE)
-		bodytemperature += 11
-	else
-		bodytemperature += BODYTEMP_HEATING_MAX
-	return
+	
+	var/burn_temperature = fire_burn_temperature()
+	var/thermal_protection = get_heat_protection(burn_temperature)
+	
+	if (thermal_protection < 1 && bodytemperature < burn_temperature)
+		bodytemperature += round(BODYTEMP_HEATING_MAX*(1-thermal_protection), 1)
 
 #undef HUMAN_MAX_OXYLOSS
 #undef HUMAN_CRIT_MAX_OXYLOSS

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -209,20 +209,34 @@
 	return
 
 /mob/living/proc/adjust_fire_stacks(add_fire_stacks) //Adjusting the amount of fire_stacks we have on person
-    fire_stacks = Clamp(fire_stacks + add_fire_stacks, min = -20, max = 20)
+    fire_stacks = Clamp(fire_stacks + add_fire_stacks, min = FIRE_MIN_STACKS, max = FIRE_MAX_STACKS)
 
 /mob/living/proc/handle_fire()
 	if(fire_stacks < 0)
 		fire_stacks = max(0, fire_stacks++) //If we've doused ourselves in water to avoid fire, dry off slowly
+	
 	if(!on_fire)
 		return 1
+	else if(fire_stacks <= 0)
+		ExtinguishMob() //Fire's been put out.
+		return 1
+	
 	var/datum/gas_mixture/G = loc.return_air() // Check if we're standing in an oxygenless environment
 	if(G.gas["oxygen"] < 1)
 		ExtinguishMob() //If there's no oxygen in the tile we're on, put out the fire
-		return
+		return 1
+	
 	var/turf/location = get_turf(src)
-	location.hotspot_expose(700, 50, 1)
+	location.hotspot_expose(fire_burn_temperature(), 50, 1)
 
 /mob/living/fire_act()
 	adjust_fire_stacks(0.5)
 	IgniteMob()
+
+//Finds the effective temperature that the mob is burning at.
+/mob/living/proc/fire_burn_temperature()
+	if (fire_stacks <= 0)
+		return 0
+	
+	//Scale quadratically so that single digit numbers of fire stacks don't burn ridiculously hot.
+	return round(FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE*(fire_stacks/FIRE_MAX_FIRESUIT_STACKS)**2)

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -68,6 +68,12 @@
 #define SHOE_MIN_COLD_PROTECTION_TEMPERATURE 2.0	//For gloves
 #define SHOE_MAX_HEAT_PROTECTION_TEMPERATURE 1500		//For gloves
 
+//Fire
+#define FIRE_MIN_STACKS -20
+#define FIRE_MAX_STACKS 25
+//If the number of stacks goes above this firesuits won't protect you anymore. If not you can walk around while on fire like a badass.
+#define FIRE_MAX_FIRESUIT_STACKS 20
+
 #define THROWFORCE_SPEED_DIVISOR 5		//The throwing speed value at which the throwforce multiplier is exactly 1.
 #define THROWNOBJ_KNOCKBACK_SPEED 15	//The minumum speed of a thrown object that will cause living mobs it hits to be knocked back.
 #define THROWNOBJ_KNOCKBACK_DIVISOR 2	//Affects how much speed the mob is knocked back with


### PR DESCRIPTION
* Temperature increase caused by being on fire is now affected by get_heat_protection().
* If a mob is on fire but it's fire_stack <= 0 then it gets extinguished, just in case.