### PR TITLE
Unfucks friendly cat AI.

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -24,6 +24,8 @@
 	maxbodytemp = 323	//Above 50 Degrees Celcius
 	holder_type = /obj/item/weapon/holder/cat
 	mob_size = 5
+	var/mob/living/carbon/human/friend
+	var/befriend_job = null
 
 /mob/living/simple_animal/cat/Life()
 	//MICE!
@@ -61,24 +63,69 @@
 			var/turf/T = spook.loc
 			var/obj/O = pick(T.contents)
 			visible_emote("suddenly stops and stares at something unseen[istype(O) ? " near [O]":""].")
-
+	if (stat || !friend)
+		return
+	if (get_dist(src, friend) <= 1)
+		if (friend.stat >= DEAD || friend.health <= config.health_threshold_softcrit)
+			if (prob((friend.stat < DEAD)? 50 : 15))
+				var/verb = pick("meows", "mews", "mrowls")
+				audible_emote(pick("[verb] in distress.", "[verb] anxiously."))
+		else
+			if (prob(5))
+				visible_emote(pick("nuzzles [friend].",
+								   "brushes against [friend].",
+								   "rubs against [friend].",
+								   "purrs."))
+	else if (friend.health <= 50)
+		if (prob(10))
+			var/verb = pick("meows", "mews", "mrowls")
+			audible_emote("[verb] anxiously.")
 /mob/living/simple_animal/cat/proc/handle_movement_target()
-	//if our target is neither inside a turf or inside a human(???), stop
-	if((movement_target) && !(isturf(movement_target.loc) || ishuman(movement_target.loc) ))
-		movement_target = null
-		stop_automated_movement = 0
-	//if we have no target or our current one is out of sight/too far away
-	if( !movement_target || !(movement_target.loc in oview(src, 4)) )
-		movement_target = null
-		stop_automated_movement = 0
-		for(var/mob/living/simple_animal/mouse/snack in oview(src)) //search for a new target
-			if(isturf(snack.loc) && !snack.stat)
-				movement_target = snack
-				break
+	if (friend)
+		var/follow_dist = 5
+		if (friend.stat >= DEAD || friend.health <= config.health_threshold_softcrit) //danger
+			follow_dist = 1
+		else if (friend.stat || friend.health <= 50) //danger or just sleeping
+			follow_dist = 2
+		var/near_dist = max(follow_dist - 2, 1)
+		var/current_dist = get_dist(src, friend)
 
-	if(movement_target)
-		stop_automated_movement = 1
-		walk_to(src,movement_target,0,3)
+		if (movement_target != friend)
+			if (current_dist > follow_dist && !istype(movement_target, /mob/living/simple_animal/mouse) && (friend in oview(src)))
+				//stop existing movement
+				walk_to(src,0)
+				turns_since_scan = 0
+
+				//walk to friend
+				stop_automated_movement = 1
+				movement_target = friend
+				walk_to(src, movement_target, near_dist, 4)
+
+		//already following and close enough, stop
+		else if (current_dist <= near_dist)
+			walk_to(src,0)
+			movement_target = null
+			stop_automated_movement = 0
+			if (prob(10))
+				say("Meow!")
+
+	if (!friend || movement_target != friend)
+		//if our target is neither inside a turf or inside a human(???), stop
+		if((movement_target) && !(isturf(movement_target.loc) || ishuman(movement_target.loc) ))
+			movement_target = null
+			stop_automated_movement = 0
+		//if we have no target or our current one is out of sight/too far away
+		if( !movement_target || !(movement_target.loc in oview(src, 4)) )
+			movement_target = null
+			stop_automated_movement = 0
+			for(var/mob/living/simple_animal/mouse/snack in oview(src)) //search for a new target
+				if(isturf(snack.loc) && !snack.stat)
+					movement_target = snack
+					break
+
+		if(movement_target)
+			stop_automated_movement = 1
+			walk_to(src,movement_target,0,3)
 
 /mob/living/simple_animal/cat/proc/handle_flee_target()
 	//see if we should stop fleeing
@@ -134,64 +181,7 @@
 		return //since the holder icon looks like a living cat
 	..()
 
-//Basic friend AI
-/mob/living/simple_animal/cat/fluff
-	var/mob/living/carbon/human/friend
-	var/befriend_job = null
-
-/mob/living/simple_animal/cat/fluff/handle_movement_target()
-	if (friend)
-		var/follow_dist = 5
-		if (friend.stat >= DEAD || friend.health <= config.health_threshold_softcrit) //danger
-			follow_dist = 1
-		else if (friend.stat || friend.health <= 50) //danger or just sleeping
-			follow_dist = 2
-		var/near_dist = max(follow_dist - 2, 1)
-		var/current_dist = get_dist(src, friend)
-
-		if (movement_target != friend)
-			if (current_dist > follow_dist && !istype(movement_target, /mob/living/simple_animal/mouse) && (friend in oview(src)))
-				//stop existing movement
-				walk_to(src,0)
-				turns_since_scan = 0
-
-				//walk to friend
-				stop_automated_movement = 1
-				movement_target = friend
-				walk_to(src, movement_target, near_dist, 4)
-
-		//already following and close enough, stop
-		else if (current_dist <= near_dist)
-			walk_to(src,0)
-			movement_target = null
-			stop_automated_movement = 0
-			if (prob(10))
-				say("Meow!")
-
-	if (!friend || movement_target != friend)
-		..()
-
-/mob/living/simple_animal/cat/fluff/Life()
-	..()
-	if (stat || !friend)
-		return
-	if (get_dist(src, friend) <= 1)
-		if (friend.stat >= DEAD || friend.health <= config.health_threshold_softcrit)
-			if (prob((friend.stat < DEAD)? 50 : 15))
-				var/verb = pick("meows", "mews", "mrowls")
-				audible_emote(pick("[verb] in distress.", "[verb] anxiously."))
-		else
-			if (prob(5))
-				visible_emote(pick("nuzzles [friend].",
-								   "brushes against [friend].",
-								   "rubs against [friend].",
-								   "purrs."))
-	else if (friend.health <= 50)
-		if (prob(10))
-			var/verb = pick("meows", "mews", "mrowls")
-			audible_emote("[verb] anxiously.")
-
-/mob/living/simple_animal/cat/fluff/verb/friend()
+/mob/living/simple_animal/cat/verb/friend()
 	set name = "Become Friends"
 	set category = "IC"
 	set src in view(1)
@@ -200,17 +190,16 @@
 		set_dir(get_dir(src, friend))
 		say("Meow!")
 		return
+	if(ishuman(usr))
+		if(befriend_job)
+			if(usr.job != befriend_job)
+				usr << "<span class='notice'>[src] ignores you.</span>"
+				return
+		friend = usr
+		set_dir(get_dir(src, friend))
+		say("Meow!")
 
-	if (!(ishuman(usr) && befriend_job && usr.job == befriend_job))
-		usr << "<span class='notice'>[src] ignores you.</span>"
-		return
-
-	friend = usr
-
-	set_dir(get_dir(src, friend))
-	say("Meow!")
-
-//RUNTIME IS ALIVE! SQUEEEEEEEE~
+//RUNTIME IS ALIVE! SQUEEEEEEEE~ // because of byond's shitty pathing system, this shit should work right and shouldn't require any map changes. Thanks BYOND.
 /mob/living/simple_animal/cat/fluff/Runtime
 	name = "Runtime"
 	desc = "Her fur has the look and feel of velvet, and her tail quivers occasionally."


### PR DESCRIPTION
This is all horrible.

I might just push this up to friendly simple_animal mobs. Who knows.

If you want to make them unfriendable by default I can always set the befriend_job to "Nonexistant" on base cats and have you override it.